### PR TITLE
Use enum for Diff operation rather than number.

### DIFF
--- a/src/diff.directive.ts
+++ b/src/diff.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, Input } from '@angular/core';
 import { DiffMatchPatchService } from './diffMatchPatch.service';
-import { Diff } from './diffMatchPatch';
+import { Diff, DiffOp } from './diffMatchPatch';
 
 @Directive({
   selector: '[diff]'
@@ -22,13 +22,13 @@ export class DiffDirective {
     for(let diff of diffs) {
       diff[1] = diff[1].replace(/\n/g, '<br/>');
 
-      if(diff[0] === 0) {
+      if(diff[0] === DiffOp.Equal) {
         html += diff[1];
       }
-      if(diff[0] === -1) {
+      if(diff[0] === DiffOp.Delete) {
         html += '<del>' + diff[1] + '</del>';
       }
-      if(diff[0] === 1) {
+      if(diff[0] === DiffOp.Insert) {
         html += '<ins>' + diff[1] + '</ins>';
       }
     }

--- a/src/diffMatchPatch.service.ts
+++ b/src/diffMatchPatch.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { DiffMatchPatch } from './diffMatchPatch';
+import { DiffMatchPatch, DiffOp } from './diffMatchPatch';
 
 @Injectable()
 export class DiffMatchPatchService {

--- a/src/lineDiff.directive.ts
+++ b/src/lineDiff.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, Input } from '@angular/core';
 import { DiffMatchPatchService } from './diffMatchPatch.service';
-import { Diff } from './diffMatchPatch';
+import { Diff, DiffOp } from './diffMatchPatch';
 
 @Directive({
   selector: '[lineDiff]',
@@ -22,13 +22,13 @@ export class LineDiffDirective {
     let html: string;
     html = '<div>';
     for(let diff of diffs) {
-      if(diff[0] === 0) {
+      if(diff[0] === DiffOp.Equal) {
         html += diff[1];
       }
-      if(diff[0] === -1) {
+      if(diff[0] === DiffOp.Delete) {
         html += '<div class=\"del\"> - <del>' + diff[1] + '</del></div>\n';
       }
-      if(diff[0] === 1) {
+      if(diff[0] === DiffOp.Insert) {
         html += '<div class=\"ins\"> + <ins>' + diff[1] + '</ins></div>\n';
       }
     }

--- a/src/processingDiff.directive.ts
+++ b/src/processingDiff.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, Input } from '@angular/core';
 import { DiffMatchPatchService } from './diffMatchPatch.service';
-import { Diff } from './diffMatchPatch';
+import { Diff, DiffOp } from './diffMatchPatch';
 
 @Directive({
   selector: '[processingDiff]'
@@ -22,13 +22,13 @@ export class ProcessingDiffDirective {
     for(let diff of diffs) {
       diff[1] = diff[1].replace(/\n/g, '<br/>');
 
-      if(diff[0] === 0) {
+      if(diff[0] === DiffOp.Equal) {
         html += diff[1];
       }
-      if(diff[0] === -1) {
+      if(diff[0] === DiffOp.Delete) {
         html += '<del>' + diff[1] + '</del>';
       }
-      if(diff[0] === 1) {
+      if(diff[0] === DiffOp.Insert) {
         html += '<ins>' + diff[1] + '</ins>';
       }
     }

--- a/src/semanticDiff.directive.ts
+++ b/src/semanticDiff.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, Input } from '@angular/core';
 import { DiffMatchPatchService } from './diffMatchPatch.service';
-import { Diff } from './diffMatchPatch';
+import { Diff, DiffOp } from './diffMatchPatch';
 
 @Directive({
   selector: '[semanticDiff]'
@@ -26,13 +26,13 @@ export class SemanticDiffDirective {
     for(let diff of diffs) {
       diff[1] = diff[1].replace(/\n/g, '<br/>');
 
-      if(diff[0] === 0) {
+      if(diff[0] === DiffOp.Equal) {
         html += diff[1];
       }
-      if(diff[0] === -1) {
+      if(diff[0] === DiffOp.Delete) {
         html += '<del>' + diff[1] + '</del>';
       }
-      if(diff[0] === 1) {
+      if(diff[0] === DiffOp.Insert) {
         html += '<ins>' + diff[1] + '</ins>';
       }
     }


### PR DESCRIPTION
Small PR to remove the 0, -1, 1 constants that occur in the directives and constrains the `Diff` type further rather than having it as `[number, string]`.