### PR TITLE
Add npmpublish script for creating a release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "types": "diffMatchPatch.module.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig-esm.json && rollup -c rollup.config.js dist/diffMatchPatch.module.js > dist/diffMatchPatch.bundle.js && cp package.json dist && ngc && cp README.md dist",
-    "test": "karma start karma.conf.js"
+    "test": "karma start karma.conf.js",
+    "npmpublish": "cd dist && npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I noticed that the 1.1.0 release that was published to npm doesn't contain the dist folder, it looks like `npm publish` was run from the root folder. I should have communicated this better in the previous PR I raised, but the expectation was that `npm publish` is run from the `dist` folder since that contains all the necessary `.js`, `.d.ts`, `README.md` and `package.json` files so it is a trimmed down package. I've tested this locally: using this structure, the client should still be able to `import { DiffMatchPatchModule } from 'ng-diff-match-patch';` after installing.

I've added a script to simplify the process so to create a release you might:
1. npm run build
2. npm run npmpublish

I noticed that the 1.1.0 package is missing the `index.ts` file as this was dropped since the `.bundle.js` that is produced under the new structure makes it unnecessary. In the meantime you might consider publishing a 1.1.1 package that includes the `index.ts` file to avoid breaking existing clients that depend on that file (if they automatically pick up `1.1.0` through semver).

Could you consider publishing a 2.0.0 that uses the new structure? That way if you're worried about clients that may have a dependency on the specific source files through e.g. `import { Diff } from 'ng-diff-match-patch/src/diffMatchPatch';` then that version won't get picked up by semver for a e.g. `^1.0.3` dependency.