### PR TITLE
Add initial LineCompare component with line numbers.

### DIFF
--- a/src/diffMatchPatch.module.ts
+++ b/src/diffMatchPatch.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { DiffDirective } from './diff.directive';
 import { LineDiffDirective } from './lineDiff.directive';
 import { ProcessingDiffDirective } from './processingDiff.directive';
 import { SemanticDiffDirective } from './semanticDiff.directive';
+import { LineCompareComponent } from './lineCompare.component';
 
 import { DiffMatchPatch } from './diffMatchPatch';
 import { DiffMatchPatchService } from './diffMatchPatch.service';
@@ -12,13 +14,18 @@ import { DiffMatchPatchService } from './diffMatchPatch.service';
     DiffDirective,
     LineDiffDirective,
     ProcessingDiffDirective,
-    SemanticDiffDirective
+    SemanticDiffDirective,
+    LineCompareComponent
+  ],
+  imports: [
+    CommonModule
   ],
   exports: [
     DiffDirective,
     LineDiffDirective,
     ProcessingDiffDirective,
-    SemanticDiffDirective
+    SemanticDiffDirective,
+    LineCompareComponent
   ],
   providers: [
     DiffMatchPatch,

--- a/src/lineCompare.component.ts
+++ b/src/lineCompare.component.ts
@@ -1,0 +1,110 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Diff, DiffOp } from './diffMatchPatch';
+import { DiffMatchPatchService } from './diffMatchPatch.service';
+
+@Component({
+  selector: 'dmp-line-compare',
+  styles: [`
+    div.dmp-line-compare-left {
+      width: 40px;
+      text-align: center;
+    }
+    div.dmp-line-compare-right {
+      width: 40px;
+      text-align: center;
+    }
+    div.dmp-line-compare-text {
+      white-space: pre-wrap;
+      border-left: 1px solid #525252;
+      padding-left: 10px;
+    }
+    .dmp-line-compare-delete {
+      background-color: #f56868;
+    }
+    .dmp-line-compare-insert {
+      background-color: #71f568;
+    }
+    .dmp-line-compare-delete>div {
+      display: inline-block;
+    }  
+    .dmp-line-compare-insert>div {
+      display: inline-block;
+    }
+    .dmp-line-compare-equal>div {
+      display: inline-block;
+    }
+  `],
+  template: `
+    <div>
+      <div [ngClass]="lineDiff[0]" *ngFor="let lineDiff of calculatedDiff">
+        <div class="dmp-line-compare-left">{{lineDiff[1]}}</div>
+        <div class="dmp-line-compare-right">{{lineDiff[2]}}</div>
+        <div class="dmp-line-compare-text">{{lineDiff[3]}}</div>
+      </div>
+    </div>
+  `
+})
+export class LineCompareComponent implements OnInit {
+  @Input()
+  public left: string | number | boolean;
+  @Input()
+  public right: string | number | boolean;
+
+  public calculatedDiff: Array<[string, string, string]>;
+
+  public constructor(
+      private dmp: DiffMatchPatchService) {}
+
+  public ngOnInit(): void {
+    if (typeof this.left === 'number' || typeof this.left === 'boolean') {
+      this.left = this.left.toString();
+    }
+    if (typeof this.right === 'number' || typeof this.right === 'boolean') {
+      this.right = this.right.toString();
+    }
+    this.calculateLineDiff(this.dmp.getLineDiff(this.left, this.right));
+  }
+
+  private calculateLineDiff(diffs: Array<Diff>): void {
+    let lineLeft: number = 1;
+    let lineRight: number = 1;
+
+    const lines: Array<[string, string, string, string]> = [];
+    for (const diff of diffs) {
+      const diffLines: string[] = diff[1].split(/\r?\n/);
+
+      // If the original line had a \r\n at the end then remove the
+      // empty string after it.
+      if (diffLines[diffLines.length - 1].length == 0) {
+        diffLines.pop();
+      }
+
+      switch (diff[0]) {
+        case DiffOp.Equal: {
+          for (const line of diffLines) {
+            lines.push(['dmp-line-compare-equal', `${lineLeft}`, `${lineRight}`, line]);
+            lineLeft++;
+            lineRight++;
+          }
+          break;
+        }
+        case DiffOp.Delete: {
+          for (const line of diffLines) {
+            lines.push(['dmp-line-compare-delete', `${lineLeft}`, '-', line]);
+            lineLeft++;
+          }
+          break;
+        }
+        case DiffOp.Insert: {
+          for (const line of diffLines) {
+            lines.push(['dmp-line-compare-insert', '-', `${lineRight}`, line]);
+            lineRight++;
+          }
+          break;
+        }
+      }
+    }
+
+    this.calculatedDiff = lines;
+  }
+}

--- a/test/lineCompare.component.spec.ts
+++ b/test/lineCompare.component.spec.ts
@@ -1,0 +1,88 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { inject, async, TestBed, ComponentFixture } from '@angular/core/testing';
+import { LineCompareComponent } from '../src/lineCompare.component';
+import { DiffMatchPatchService } from '../src/diffMatchPatch.service';
+import { Diff, DiffOp } from '../src/diffMatchPatch';
+import * as sinon from 'sinon';
+
+class DiffMatchPatchServiceMock {
+  public getLineDiff(left: string, right: string): Array<Diff> {
+    return [
+      [DiffOp.Equal, 'Diff One A\r\nDiff One B\r\n'],
+      [DiffOp.Insert, 'Diff Two A\r\nDiff Two B\r\n'],
+      [DiffOp.Delete, 'Diff Three A\r\nDiff Three B'],
+      [DiffOp.Equal, 'Diff Four A\r\nDiff Four B\r\n']
+    ];
+  }
+}
+
+describe('LineCompareComponent', () => {
+  let component: LineCompareComponent;
+  let fixture: ComponentFixture<LineCompareComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LineCompareComponent ],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: DiffMatchPatchService, useClass: DiffMatchPatchServiceMock }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LineCompareComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should initialise component', () => {
+    expect(fixture).toBeDefined();
+    expect(component).toBeDefined();
+  });
+
+  it('should have 8 line diffs', () => {
+    expect(component.calculatedDiff.length).toBe(8);
+  });
+
+  it('should have correct line numbers', () => {
+    const leftLineNumbers = component.calculatedDiff.map(x => x[1]);
+    expect(leftLineNumbers).toEqual([
+      '1', '2', '-', '-', '3', '4', '5', '6'
+    ]);
+
+    const rightLineNumbers = component.calculatedDiff.map(x => x[2]);
+    expect(rightLineNumbers).toEqual([
+      '1', '2', '3', '4', '-', '-', '5', '6'
+    ]);
+  });
+
+  it('should have correct class annotations', () => {
+    const classes = component.calculatedDiff.map(x => x[0]);
+    expect(classes).toEqual([
+      'dmp-line-compare-equal',
+      'dmp-line-compare-equal',
+      'dmp-line-compare-insert',
+      'dmp-line-compare-insert',
+      'dmp-line-compare-delete',
+      'dmp-line-compare-delete',
+      'dmp-line-compare-equal',
+      'dmp-line-compare-equal'
+    ]);
+  });
+
+  it('should have correct line contents', () => {
+    const contents = component.calculatedDiff.map(x => x[3]);
+    expect(contents).toEqual([
+      'Diff One A',
+      'Diff One B',
+      'Diff Two A',
+      'Diff Two B',
+      'Diff Three A',
+      'Diff Three B',
+      'Diff Four A',
+      'Diff Four B'
+    ]);
+  });
+});


### PR DESCRIPTION
I'd like to add to this library something that is similar to a line diff you might find in a diffing tool for code reviews. This is related to issue https://github.com/elliotforbes/ng-diff-match-patch/issues/3 and https://github.com/elliotforbes/ng-diff-match-patch/issues/2.

This PR is an initial concept. It adds CSS classes so that it is easier for clients to customise the appearance of the diff. I'd like to improve it further by adding an option for only showing the context around actual diffs, e.g. showing +/- 5 lines above and below an Insert/Delete but hiding the rest of the Equal portions. This makes it easier to review diffs of large files that only have a few changes.

I thought I'd raise this PR to see if anyone had any thoughts on this before spending too much time on it.

It can be used like the following:
```
<dmp-line-compare [left]="left" [right]="right"></dmp-line-compare>
```
Here is an example of the result in Chrome:
![image](https://user-images.githubusercontent.com/2265225/28247708-e0af815e-6a2d-11e7-8576-9f3db137f9cf.png)
