### PR TITLE
Improve styling on lineChange diff component.

### DIFF
--- a/src/lineCompare.component.ts
+++ b/src/lineCompare.component.ts
@@ -5,24 +5,64 @@ import { DiffMatchPatchService } from './diffMatchPatch.service';
 @Component({
   selector: 'dmp-line-compare',
   styles: [`
+    div.dmp-line-compare {
+      display: flex;
+      flex-direction: row;
+      border: 1px solid #808080;
+      font-family: Consolas, Courier, monospace;
+      width: 911px;
+    }
+    div.dmp-line-compare-margin {
+      width: 101px;
+    }
+    div.dmp-line-compare-content {
+      position: relative;
+      top: 0px;
+      left: 0px;
+      flex-grow: 1;
+      overflow-x: scroll;
+    }
+    div.dmp-line-compare-content-wrapper {
+      position: absolute;
+      top: 0px;
+      left: 0px;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+    }
     div.dmp-line-compare-left {
-      width: 40px;
+      width: 50px;
       text-align: center;
+      color: #484848;
     }
-    div.dmp-line-compare-right {
-      width: 40px;
-      text-align: center;
+    div.dmp-line-compare-equal>div.dmp-line-compare-left,
+      div.dmp-line-compare-equal>div.dmp-line-compare-right {
+      background-color: #dedede;
     }
-    div.dmp-line-compare-text {
-      white-space: pre-wrap;
-      border-left: 1px solid #525252;
-      padding-left: 10px;
+    div.dmp-line-compare-insert>div.dmp-line-compare-left,
+      div.dmp-line-compare-insert>div.dmp-line-compare-right {
+      background-color: #8bfb6f;
     }
-    .dmp-line-compare-delete {
+    div.dmp-line-compare-delete>div.dmp-line-compare-left,
+      div.dmp-line-compare-delete>div.dmp-line-compare-right {
       background-color: #f56868;
     }
+    div.dmp-line-compare-right {
+      width: 50px;
+      text-align: center;
+      color: #484848;
+      border-right: 1px solid #888888;
+    }
+    div.dmp-line-compare-text {
+      white-space: pre;
+      padding-left: 10px;
+      min-width: 800px;
+    }
+    .dmp-line-compare-delete {
+      background-color: #ff8c8c;
+    }
     .dmp-line-compare-insert {
-      background-color: #71f568;
+      background-color: #9dff97;
     }
     .dmp-line-compare-delete>div {
       display: inline-block;
@@ -33,13 +73,27 @@ import { DiffMatchPatchService } from './diffMatchPatch.service';
     .dmp-line-compare-equal>div {
       display: inline-block;
     }
+    .dmp-margin-bottom-spacer {
+      height: 20px;
+      background-color: #dedede;
+      border-right: 1px solid #888888;
+    }
   `],
   template: `
-    <div>
-      <div [ngClass]="lineDiff[0]" *ngFor="let lineDiff of calculatedDiff">
-        <div class="dmp-line-compare-left">{{lineDiff[1]}}</div>
-        <div class="dmp-line-compare-right">{{lineDiff[2]}}</div>
-        <div class="dmp-line-compare-text">{{lineDiff[3]}}</div>
+    <div class="dmp-line-compare">
+      <div class="dmp-line-compare-margin">
+        <div [ngClass]="lineDiff[0]" *ngFor="let lineDiff of calculatedDiff">
+          <div class="dmp-line-compare-left">{{lineDiff[1]}}</div><!-- No space
+        --><div class="dmp-line-compare-right">{{lineDiff[2]}}</div>
+        </div>
+        <div class="dmp-margin-bottom-spacer"></div>
+      </div><!-- No space
+  --><div class="dmp-line-compare-content">
+        <div class="dmp-line-compare-content-wrapper">
+          <div [ngClass]="lineDiff[0]" *ngFor="let lineDiff of calculatedDiff">
+            <div class="dmp-line-compare-text">{{lineDiff[3]}}</div>
+          </div>
+        </div>
       </div>
     </div>
   `


### PR DESCRIPTION
Allowed the diff content to be horizontally scrollable if its content overflows and extended the line highlighting to expand with it.

For example:
![image](https://user-images.githubusercontent.com/2265225/28494056-0791b6c4-6f1b-11e7-8663-1b437b2e3549.png)
