### PR TITLE
Control the amount of context supplied around insert/delete diffs in lineCompare.

### DIFF
--- a/src/lineCompare.component.ts
+++ b/src/lineCompare.component.ts
@@ -2,6 +2,17 @@ import { Component, Input, OnInit } from '@angular/core';
 import { Diff, DiffOp } from './diffMatchPatch';
 import { DiffMatchPatchService } from './diffMatchPatch.service';
 
+/* Holds the state of the calculation of the diff result we intend to display.
+ *  > lines contains the data that will be displayed on screen.
+ *  > lineLeft keeps track of the document line number in the [left] input.
+ *  > lineRight keeps track of the document line number in the [right] input.
+ */
+type DiffCalculation = {
+  lines: Array<[string, string, string, string]>,
+  lineLeft: number,
+  lineRight: number
+};
+
 @Component({
   selector: 'dmp-line-compare',
   styles: [`
@@ -35,7 +46,10 @@ import { DiffMatchPatchService } from './diffMatchPatch.service';
     }
   `],
   template: `
-    <div>
+    <div class="dmp-line-compare-no-changes-text" *ngIf="isContentEqual">
+      There are no changes to display.
+    </div>    
+    <div *ngIf="!isContentEqual">
       <div [ngClass]="lineDiff[0]" *ngFor="let lineDiff of calculatedDiff">
         <div class="dmp-line-compare-left">{{lineDiff[1]}}</div>
         <div class="dmp-line-compare-right">{{lineDiff[2]}}</div>
@@ -49,8 +63,13 @@ export class LineCompareComponent implements OnInit {
   public left: string | number | boolean;
   @Input()
   public right: string | number | boolean;
+  // The number of lines of context to provide either side of a DiffOp.Insert or DiffOp.Delete diff.
+  // Context is taken from a DiffOp.Equal section.
+  @Input()
+  public lineContextSize: number;
 
   public calculatedDiff: Array<[string, string, string]>;
+  public isContentEqual: boolean;
 
   public constructor(
       private dmp: DiffMatchPatchService) {}
@@ -66,12 +85,21 @@ export class LineCompareComponent implements OnInit {
   }
 
   private calculateLineDiff(diffs: Array<Diff>): void {
-    let lineLeft: number = 1;
-    let lineRight: number = 1;
+    const diffCalculation: DiffCalculation = {
+      lines: [],
+      lineLeft: 1,
+      lineRight: 1
+    };
 
-    const lines: Array<[string, string, string, string]> = [];
-    for (const diff of diffs) {
-      const diffLines: string[] = diff[1].split(/\r?\n/);
+    this.isContentEqual = diffs.length === 1 && diffs[0][0] === DiffOp.Equal;
+    if (this.isContentEqual) {
+      this.calculatedDiff = [];
+      return;
+    }
+
+    for (let i = 0; i < diffs.length; i++) {
+      const diff = diffs[i];
+      let diffLines: string[] = diff[1].split(/\r?\n/);
 
       // If the original line had a \r\n at the end then remove the
       // empty string after it.
@@ -81,30 +109,101 @@ export class LineCompareComponent implements OnInit {
 
       switch (diff[0]) {
         case DiffOp.Equal: {
-          for (const line of diffLines) {
-            lines.push(['dmp-line-compare-equal', `${lineLeft}`, `${lineRight}`, line]);
-            lineLeft++;
-            lineRight++;
-          }
+          const isFirstDiff = i === 0;
+          const isLastDiff = i === diffs.length - 1;
+          this.outputEqualDiff(diffLines, diffCalculation, isFirstDiff, isLastDiff);
           break;
         }
         case DiffOp.Delete: {
-          for (const line of diffLines) {
-            lines.push(['dmp-line-compare-delete', `${lineLeft}`, '-', line]);
-            lineLeft++;
-          }
+          this.outputDeleteDiff(diffLines, diffCalculation);
           break;
         }
         case DiffOp.Insert: {
-          for (const line of diffLines) {
-            lines.push(['dmp-line-compare-insert', '-', `${lineRight}`, line]);
-            lineRight++;
-          }
+          this.outputInsertDiff(diffLines, diffCalculation);
           break;
         }
       }
     }
 
-    this.calculatedDiff = lines;
+    this.calculatedDiff = diffCalculation.lines;
+  }
+
+  /* If the number of diffLines is greater than lineContextSize then we may need to adjust the diff
+   * that is output.
+   *   > If the first diff of a document is DiffOp.Equal then the leading lines can be dropped
+   *     leaving the last 'lineContextSize' lines for context.
+   *   > If the last diff of a document is DiffOp.Equal then the trailing lines can be dropped
+   *     leaving the first 'lineContextSize' lines for context.
+   *   > If the diff is a DiffOp.Equal occurs in the middle then the diffs either side of it must be
+   *     DiffOp.Insert or DiffOp.Delete. If it has more than 2 * 'lineContextSize' lines of content
+   *     then the middle lines are dropped leaving the first 'lineContextSize' and last 'lineContextSize'
+   *     lines for context. A special line is inserted with '...' indicating that content is skipped.
+   *
+   * A document cannot consist of a single Diff with DiffOp.Equal and reach this function because
+   * in this case the calculateLineDiff method returns early.
+   */
+  private outputEqualDiff(
+      diffLines: string[],
+      diffCalculation: DiffCalculation,
+      isFirstDiff: boolean,
+      isLastDiff: boolean): void {
+    if (this.lineContextSize && diffLines.length > this.lineContextSize) {
+      if (isFirstDiff) {
+        // Take the last 'lineContextSize' lines from the first diff
+        const lineIncrement = diffLines.length - this.lineContextSize;
+        diffCalculation.lineLeft += lineIncrement;
+        diffCalculation.lineRight += lineIncrement;
+        diffLines = diffLines.slice(diffLines.length - this.lineContextSize, diffLines.length);
+      }
+      else if (isLastDiff) {
+        // Take only the first 'lineContextSize' lines from the final diff
+        diffLines = diffLines.slice(0, this.lineContextSize);
+      }
+      else if (diffLines.length > 2 * this.lineContextSize) {
+        // Take the first 'lineContextSize' lines from this diff to provide context for the last diff
+        this.outputEqualDiffLines(diffLines.slice(0, this.lineContextSize), diffCalculation);
+
+        // Output a special line indicating that some content is equal and has been skipped
+        diffCalculation.lines.push(['dmp-line-compare-equal', '...', '...', '...']);
+        const numberOfSkippedLines = diffLines.length - (2 * this.lineContextSize);
+        diffCalculation.lineLeft += numberOfSkippedLines;
+        diffCalculation.lineRight += numberOfSkippedLines;
+
+        // Take the last 'lineContextSize' lines from this diff to provide context for the next diff
+        this.outputEqualDiffLines(diffLines.slice(diffLines.length - this.lineContextSize), diffCalculation);
+        // This if branch has already output the diff lines so we return early to avoid outputting the lines
+        // at the end of the method.
+        return;
+      }
+    }
+    this.outputEqualDiffLines(diffLines, diffCalculation);
+  }
+
+  private outputEqualDiffLines(
+      diffLines: string[],
+      diffCalculation: DiffCalculation): void {
+    for (const line of diffLines) {
+      diffCalculation.lines.push(['dmp-line-compare-equal', `${diffCalculation.lineLeft}`, `${diffCalculation.lineRight}`, line]);
+      diffCalculation.lineLeft++;
+      diffCalculation.lineRight++;
+    }
+  }
+
+  private outputDeleteDiff(
+      diffLines: string[],
+      diffCalculation: DiffCalculation): void {
+    for (const line of diffLines) {
+      diffCalculation.lines.push(['dmp-line-compare-delete', `${diffCalculation.lineLeft}`, '-', line]);
+      diffCalculation.lineLeft++;
+    }
+  }
+
+  private outputInsertDiff(
+      diffLines: string[],
+      diffCalculation: DiffCalculation): void {
+    for (const line of diffLines) {
+      diffCalculation.lines.push(['dmp-line-compare-insert', '-', `${diffCalculation.lineRight}`, line]);
+      diffCalculation.lineRight++;
+    }
   }
 }


### PR DESCRIPTION
For large diffs, the user might want to hide the bits that match between left and right and only show the insert/deletes. They may want to see some context so this parameter allows the user to set e.g. `[lineContextSize]="5"` to show +/- 5 lines of context around an insert/delete.

For example:
![image](https://user-images.githubusercontent.com/2265225/28495361-26378974-6f42-11e7-9aca-3fb9c673f951.png)
