### PR TITLE
chore(inline-sourcemaps): tsconfig change to inline source

### DIFF
--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "es2015",
     "sourceMap": true,
+    "inlineSources": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "sourceMap": true,
+    "inlineSources": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "declaration": true,


### PR DESCRIPTION
The sourcemaps point to the source location as `../src` which isn't contained in the published package. This config change inlines the source code into the `.map` files so that we don't need to include the `.ts` source in the published package.